### PR TITLE
Remove special handling of goto clicks.

### DIFF
--- a/src/net/sf/freecol/client/gui/CanvasMouseListener.java
+++ b/src/net/sf/freecol/client/gui/CanvasMouseListener.java
@@ -124,6 +124,7 @@ public final class CanvasMouseListener extends FreeColClientHolder
         doubleClickTimer.stop();
         Tile tile = canvas.convertToMapTile(centerX, centerY);
         if (tile == null) return;
+        if (flushGoto()) return;
 
         switch (canvas.getViewMode()) {
         case GUI.MOVE_UNITS_MODE:
@@ -210,7 +211,5 @@ public final class CanvasMouseListener extends FreeColClientHolder
      */
     public void mouseReleased(MouseEvent e) {
         if (!e.getComponent().isEnabled()) return;
-
-        flushGoto();
     }
 }


### PR DESCRIPTION
There is a bug currently, because the tile is selected twice. First mousePressed saves the coordinates of the click and waits to know if another click comes. In the meantime mouseReleased calls flushGoto and selects the goal tile, but can also scroll the map if the unit centering option is set.
After the doubleClickTimer fires, the saved coordinates are used to select the tile under the cursor, but after scrolling it is not the same tile anymore where the click started.