### PR TITLE
Dont allow naval units to find path in unexplored terrain

### DIFF
--- a/src/net/sf/freecol/common/model/Unit.java
+++ b/src/net/sf/freecol/common/model/Unit.java
@@ -2218,9 +2218,12 @@ public class Unit extends GoodsLocation
                     ? MoveType.ATTACK_UNIT
                     : MoveType.MOVE_NO_ATTACK_CIVILIAN;
             } else {
-                return (target.isDirectlyHighSeasConnected())
-                    ? MoveType.MOVE_HIGH_SEAS
-                    : MoveType.MOVE;
+                if (target.isExplored()) {
+                    return (target.isDirectlyHighSeasConnected())
+                            ? MoveType.MOVE_HIGH_SEAS
+                            : MoveType.MOVE;
+                    } else
+                        return MoveType.MOVE_ILLEGAL;
             }
         }
     }


### PR DESCRIPTION
Only allow naval units to find paths travering explored tiles.
This will fix annoying bugs like routing naval units over land (if land is unexplored)