### PR TITLE
Adds ability to record creator name field and a description field in map editor

### DIFF
--- a/data/strings/FreeColMessages.properties
+++ b/data/strings/FreeColMessages.properties
@@ -61,6 +61,7 @@ close=Close
 color=Color
 connect=Connect
 current=Current
+description=Description
 false=False
 fill=Fill
 height=Height
@@ -3547,6 +3548,9 @@ mapGeneratorOptionsDialog.badWidth=Map width (%width%) is too narrow, less than 
 
 # MapSizeDialog
 mapSizeDialog.mapSize=Select map size
+
+# MapAuthorshipDialog
+mapAuthorshipDialog.mapAuthorship=Enter map details
 
 # ModifierFormat
 modifierFormat.unknown=???

--- a/src/net/sf/freecol/client/control/MapEditorController.java
+++ b/src/net/sf/freecol/client/control/MapEditorController.java
@@ -19,36 +19,29 @@
 
 package net.sf.freecol.client.control;
 
+import net.sf.freecol.FreeCol;
+import net.sf.freecol.client.FreeColClient;
+import net.sf.freecol.client.gui.GUI;
+import net.sf.freecol.common.model.MapDetails;
+import net.sf.freecol.common.FreeColException;
+import net.sf.freecol.common.i18n.Messages;
+import net.sf.freecol.common.io.FreeColDirectories;
+import net.sf.freecol.common.io.FreeColSavegameFile;
+import net.sf.freecol.common.model.*;
+import net.sf.freecol.common.option.MapGeneratorOptions;
+import net.sf.freecol.common.option.OptionGroup;
+import net.sf.freecol.server.FreeColServer;
+import net.sf.freecol.server.generator.MapGenerator;
+import net.sf.freecol.server.model.ServerGame;
+import net.sf.freecol.server.model.ServerPlayer;
+
+import javax.swing.*;
+import javax.xml.stream.XMLStreamException;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.logging.Logger;
-
-import javax.swing.SwingUtilities;
-import javax.xml.stream.XMLStreamException;
-
-import net.sf.freecol.FreeCol;
-import net.sf.freecol.client.FreeColClient;
-import net.sf.freecol.client.gui.GUI;
-import net.sf.freecol.common.FreeColException;
-import net.sf.freecol.common.i18n.Messages;
-import net.sf.freecol.common.io.FreeColDirectories;
-import net.sf.freecol.common.io.FreeColSavegameFile;
-import net.sf.freecol.common.model.Game;
-import net.sf.freecol.common.model.Map;
-import net.sf.freecol.common.model.Nation;
-import net.sf.freecol.common.model.Player;
-import net.sf.freecol.common.model.Specification;
-import net.sf.freecol.common.model.StringTemplate;
-import net.sf.freecol.common.model.Tile;
-import net.sf.freecol.common.option.MapGeneratorOptions;
-import net.sf.freecol.common.option.OptionGroup;
-import net.sf.freecol.common.util.LogBuilder;
-import net.sf.freecol.server.FreeColServer;
-import net.sf.freecol.server.generator.MapGenerator;
-import net.sf.freecol.server.model.ServerGame;
-import net.sf.freecol.server.model.ServerPlayer;
 
 
 /**
@@ -191,23 +184,29 @@ public final class MapEditorController extends FreeColClientHolder {
     }
 
     /**
-     * Opens a dialog where the user should specify the filename
-     * and saves the game.
+     * Opens a dialog asking for map details and then a dialog
+     * where the user should specify the filename and saves
+     * the game.
      */
     public void saveMapEditorGame() {
         File dir = FreeColDirectories.getUserMapsDirectory();
         if (dir == null) dir = FreeColDirectories.getSaveDirectory();
-        File file = getGUI()
-            .showSaveDialog(dir, FreeColDirectories.MAP_FILE_NAME);
-        if (file != null) saveMapEditorGame(file);
+        MapDetails mapDetails = getGUI().showMapDetailsDialog();
+
+        if (mapDetails != null) {
+            File file = getGUI()
+                    .showSaveDialog(dir, FreeColDirectories.MAP_FILE_NAME);
+            if (file != null) saveMapEditorGame(file, mapDetails);
+        }
     }
 
     /**
      * Saves the game to the given file.
      *
      * @param file The {@code File}.
+     * @param mapDetails The {@code MapDetails}.
      */
-    public void saveMapEditorGame(final File file) {
+    public void saveMapEditorGame(final File file, final MapDetails mapDetails) {
         final GUI gui = getGUI();
         final Game game = getGame();
         Map map = game.getMap();
@@ -221,7 +220,7 @@ public final class MapEditorController extends FreeColClientHolder {
             public void run() {
                 try {
                     BufferedImage thumb = gui.createMiniMapThumbNail();
-                    getFreeColServer().saveMapEditorGame(file, thumb);
+                    getFreeColServer().saveMapEditorGame(file, thumb, mapDetails);
                     SwingUtilities.invokeLater(() -> {
                             gui.closeStatusPanel();
                             gui.requestFocusInWindow();

--- a/src/net/sf/freecol/client/gui/Canvas.java
+++ b/src/net/sf/freecol/client/gui/Canvas.java
@@ -19,18 +19,30 @@
 
 package net.sf.freecol.client.gui;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.GraphicsDevice;
-import java.awt.Image;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
+import net.sf.freecol.FreeCol;
+import net.sf.freecol.client.ClientOptions;
+import net.sf.freecol.client.FreeColClient;
+import net.sf.freecol.client.gui.action.FreeColAction;
+import net.sf.freecol.client.gui.dialog.*;
+import net.sf.freecol.client.gui.panel.*;
+import net.sf.freecol.client.gui.panel.colopedia.ColopediaPanel;
+import net.sf.freecol.client.gui.panel.report.*;
+import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
+import net.sf.freecol.common.i18n.Messages;
+import net.sf.freecol.common.io.FreeColDataFile;
+import net.sf.freecol.common.metaserver.ServerInfo;
+import net.sf.freecol.common.model.*;
+import net.sf.freecol.common.model.Monarch.MonarchAction;
+import net.sf.freecol.common.option.IntegerOption;
+import net.sf.freecol.common.option.Option;
+import net.sf.freecol.common.option.OptionGroup;
+import net.sf.freecol.common.util.Utils;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.plaf.basic.BasicInternalFrameUI;
+import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseListener;
@@ -44,141 +56,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.ImageIcon;
-import javax.swing.JComponent;
-import javax.swing.JDesktopPane;
-import javax.swing.JInternalFrame;
-import javax.swing.JLayeredPane;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.border.EmptyBorder;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.plaf.basic.BasicInternalFrameUI;
-
-import net.sf.freecol.FreeCol;
-import net.sf.freecol.client.ClientOptions;
-import net.sf.freecol.client.FreeColClient;
-import net.sf.freecol.client.gui.action.FreeColAction;
-import net.sf.freecol.client.gui.panel.AboutPanel;
-import net.sf.freecol.client.gui.panel.BuildQueuePanel;
-import net.sf.freecol.client.gui.dialog.CaptureGoodsDialog;
-import net.sf.freecol.client.gui.panel.ChatPanel;
-import net.sf.freecol.client.gui.dialog.ChooseFoundingFatherDialog;
-import net.sf.freecol.client.gui.dialog.ClientOptionsDialog;
-import net.sf.freecol.client.gui.panel.ColonyPanel;
-import net.sf.freecol.client.gui.panel.colopedia.ColopediaPanel;
-import net.sf.freecol.client.gui.panel.ColorChooserPanel;
-import net.sf.freecol.client.gui.panel.report.CompactLabourReport;
-import net.sf.freecol.client.gui.dialog.ConfirmDeclarationDialog;
-import net.sf.freecol.client.gui.panel.DeclarationPanel;
-import net.sf.freecol.client.gui.dialog.DifficultyDialog;
-import net.sf.freecol.client.gui.dialog.DumpCargoDialog;
-import net.sf.freecol.client.gui.dialog.EditOptionDialog;
-import net.sf.freecol.client.gui.dialog.EditSettlementDialog;
-import net.sf.freecol.client.gui.dialog.EmigrationDialog;
-import net.sf.freecol.client.gui.dialog.EndTurnDialog;
-import net.sf.freecol.client.gui.panel.ErrorPanel;
-import net.sf.freecol.client.gui.panel.EuropePanel;
-import net.sf.freecol.client.gui.panel.EventPanel;
-import net.sf.freecol.client.gui.panel.FindSettlementPanel;
-import net.sf.freecol.client.gui.dialog.FirstContactDialog;
-import net.sf.freecol.client.gui.dialog.FreeColChoiceDialog;
-import net.sf.freecol.client.gui.dialog.FreeColConfirmDialog;
-import net.sf.freecol.client.gui.dialog.FreeColDialog;
-import net.sf.freecol.client.gui.panel.FreeColPanel;
-import net.sf.freecol.client.gui.dialog.FreeColStringInputDialog;
-import net.sf.freecol.client.gui.dialog.GameOptionsDialog;
-import net.sf.freecol.client.gui.panel.IndianSettlementPanel;
-import net.sf.freecol.client.gui.panel.InformationPanel;
-import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
-import net.sf.freecol.client.gui.dialog.LoadDialog;
-import net.sf.freecol.client.gui.dialog.LoadingSavegameDialog;
-import net.sf.freecol.client.gui.panel.MainPanel;
-import net.sf.freecol.client.gui.panel.MapEditorTransformPanel;
-import net.sf.freecol.client.gui.dialog.MapGeneratorOptionsDialog;
-import net.sf.freecol.client.gui.dialog.MapSizeDialog;
-import net.sf.freecol.client.gui.dialog.MonarchDialog;
-import net.sf.freecol.client.gui.dialog.NativeDemandDialog;
-import net.sf.freecol.client.gui.dialog.NegotiationDialog;
-import net.sf.freecol.client.gui.panel.NewPanel;
-import net.sf.freecol.client.gui.dialog.Parameters;
-import net.sf.freecol.client.gui.dialog.ParametersDialog;
-import net.sf.freecol.client.gui.dialog.PreCombatDialog;
-import net.sf.freecol.client.gui.panel.PurchasePanel;
-import net.sf.freecol.client.gui.panel.RecruitPanel;
-import net.sf.freecol.client.gui.panel.report.ReportCargoPanel;
-import net.sf.freecol.client.gui.panel.report.ReportClassicColonyPanel;
-import net.sf.freecol.client.gui.panel.report.ReportCompactColonyPanel;
-import net.sf.freecol.client.gui.panel.report.ReportContinentalCongressPanel;
-import net.sf.freecol.client.gui.panel.report.ReportEducationPanel;
-import net.sf.freecol.client.gui.panel.report.ReportExplorationPanel;
-import net.sf.freecol.client.gui.panel.report.ReportForeignAffairPanel;
-import net.sf.freecol.client.gui.panel.report.ReportHighScoresPanel;
-import net.sf.freecol.client.gui.panel.report.ReportHistoryPanel;
-import net.sf.freecol.client.gui.panel.report.ReportIndianPanel;
-import net.sf.freecol.client.gui.panel.report.ReportLabourDetailPanel;
-import net.sf.freecol.client.gui.panel.report.ReportLabourPanel;
-import net.sf.freecol.client.gui.panel.report.ReportMilitaryPanel;
-import net.sf.freecol.client.gui.panel.report.ReportNavalPanel;
-import net.sf.freecol.client.gui.panel.report.ReportPanel;
-import net.sf.freecol.client.gui.panel.report.ReportProductionPanel;
-import net.sf.freecol.client.gui.panel.report.ReportReligiousPanel;
-import net.sf.freecol.client.gui.panel.report.ReportRequirementsPanel;
-import net.sf.freecol.client.gui.panel.report.ReportTradePanel;
-import net.sf.freecol.client.gui.panel.report.ReportTurnPanel;
-import net.sf.freecol.client.gui.dialog.RiverStyleDialog;
-import net.sf.freecol.client.gui.dialog.SaveDialog;
-import net.sf.freecol.client.gui.dialog.ScaleMapSizeDialog;
-import net.sf.freecol.client.gui.dialog.SelectAmountDialog;
-import net.sf.freecol.client.gui.dialog.SelectDestinationDialog;
-import net.sf.freecol.client.gui.dialog.SelectTributeAmountDialog;
-import net.sf.freecol.client.gui.panel.ServerListPanel;
-import net.sf.freecol.client.gui.panel.StartGamePanel;
-import net.sf.freecol.client.gui.panel.StatisticsPanel;
-import net.sf.freecol.client.gui.panel.StatusPanel;
-import net.sf.freecol.client.gui.panel.TilePanel;
-import net.sf.freecol.client.gui.panel.TradeRouteInputPanel;
-import net.sf.freecol.client.gui.panel.TradeRoutePanel;
-import net.sf.freecol.client.gui.panel.TrainPanel;
-import net.sf.freecol.client.gui.panel.Utility;
-import net.sf.freecol.client.gui.dialog.VictoryDialog;
-import net.sf.freecol.client.gui.dialog.WarehouseDialog;
-import net.sf.freecol.client.gui.panel.WorkProductionPanel;
-import net.sf.freecol.common.i18n.Messages;
-import net.sf.freecol.common.io.FreeColDataFile;
-import net.sf.freecol.common.metaserver.ServerInfo;
-import net.sf.freecol.common.model.Colony;
-import net.sf.freecol.common.model.DiplomaticTrade;
-import net.sf.freecol.common.model.Direction;
-import net.sf.freecol.common.model.FoundingFather;
-import net.sf.freecol.common.model.FreeColGameObject;
-import net.sf.freecol.common.model.FreeColObject;
-import net.sf.freecol.common.model.Game;
-import net.sf.freecol.common.model.Goods;
-import net.sf.freecol.common.model.GoodsType;
-import net.sf.freecol.common.model.HighScore;
-import net.sf.freecol.common.model.IndianSettlement;
-import net.sf.freecol.common.model.Location;
-import net.sf.freecol.common.model.ModelMessage;
-import net.sf.freecol.common.model.Monarch.MonarchAction;
-import net.sf.freecol.common.model.PathNode;
-import net.sf.freecol.common.model.Player;
-import net.sf.freecol.common.model.Settlement;
-import net.sf.freecol.common.model.Specification;
-import net.sf.freecol.common.model.StringTemplate;
-import net.sf.freecol.common.model.Tile;
-import net.sf.freecol.common.model.TradeRoute;
-import net.sf.freecol.common.model.TypeCountMap;
-import net.sf.freecol.common.model.Unit;
-import net.sf.freecol.common.model.UnitType;
-import net.sf.freecol.common.option.IntegerOption;
-import net.sf.freecol.common.option.Option;
-import net.sf.freecol.common.option.OptionGroup;
-import static net.sf.freecol.common.util.CollectionUtils.*;
-import static net.sf.freecol.common.util.StringUtils.*;
-import net.sf.freecol.common.util.Utils;
+import static net.sf.freecol.common.util.CollectionUtils.transform;
+import static net.sf.freecol.common.util.StringUtils.lastPart;
 
 
 /**
@@ -2785,5 +2664,14 @@ public final class Canvas extends JDesktopPane {
         addMouseListener(ml);
         addKeyListener(kl);
         addCentered(vp, JLayeredPane.PALETTE_LAYER);
+    }
+
+    /**
+     * Display the map details dialog.
+     *
+     * @return The response returned by the dialog.
+     */
+    public MapDetails showMapDetailsDialog() {
+        return showFreeColDialog(new MapDetailsDialog(freeColClient, frame), null);
     }
 }

--- a/src/net/sf/freecol/client/gui/GUI.java
+++ b/src/net/sf/freecol/client/gui/GUI.java
@@ -19,82 +19,41 @@
 
 package net.sf.freecol.client.gui;
 
-import java.awt.Component;
-import java.awt.Dimension;
+import net.sf.freecol.FreeCol;
+import net.sf.freecol.client.ClientOptions;
+import net.sf.freecol.client.FreeColClient;
+import net.sf.freecol.client.control.FreeColClientHolder;
+import net.sf.freecol.client.control.MapTransform;
+import net.sf.freecol.client.gui.dialog.FreeColDialog;
+import net.sf.freecol.common.model.MapDetails;
+import net.sf.freecol.client.gui.dialog.Parameters;
+import net.sf.freecol.client.gui.panel.*;
+import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
+import net.sf.freecol.common.FreeColException;
+import net.sf.freecol.common.debug.DebugUtils;
+import net.sf.freecol.common.debug.FreeColDebugger;
+import net.sf.freecol.common.i18n.Messages;
+import net.sf.freecol.common.metaserver.ServerInfo;
+import net.sf.freecol.common.model.*;
+import net.sf.freecol.common.model.Constants.*;
+import net.sf.freecol.common.model.Monarch.MonarchAction;
+import net.sf.freecol.common.option.Option;
+import net.sf.freecol.common.option.OptionGroup;
+import net.sf.freecol.common.resources.ResourceManager;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionListener;
-import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.awt.Point;
-import java.awt.Rectangle;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.Map;
-
-import javax.swing.ImageIcon;
-import javax.swing.SwingUtilities;
-
-import net.sf.freecol.FreeCol;
-import net.sf.freecol.client.ClientOptions;
-import net.sf.freecol.client.FreeColClient;
-import net.sf.freecol.client.control.FreeColClientHolder;
-import net.sf.freecol.client.control.MapTransform;
-import net.sf.freecol.client.gui.panel.BuildQueuePanel;
-import net.sf.freecol.client.gui.panel.ColonyPanel;
-import net.sf.freecol.client.gui.panel.ColorChooserPanel;
-import net.sf.freecol.client.gui.panel.FreeColPanel;
-import net.sf.freecol.client.gui.panel.MiniMap;
-import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
-import net.sf.freecol.client.gui.panel.TradeRouteInputPanel;
-import net.sf.freecol.client.gui.dialog.FreeColDialog;
-import net.sf.freecol.client.gui.dialog.Parameters;
-import net.sf.freecol.common.FreeColException;
-import net.sf.freecol.common.debug.DebugUtils;
-import net.sf.freecol.common.debug.FreeColDebugger;
-import net.sf.freecol.common.i18n.Messages;
-import net.sf.freecol.common.io.FreeColDirectories;
-import net.sf.freecol.common.metaserver.ServerInfo;
-import net.sf.freecol.common.model.Ability;
-import net.sf.freecol.common.model.Building;
-import net.sf.freecol.common.model.Colony;
-import net.sf.freecol.common.model.Constants.*; // Imports all ENUMS.
-import net.sf.freecol.common.model.DiplomaticTrade;
-import net.sf.freecol.common.model.Europe;
-import net.sf.freecol.common.model.FoundingFather;
-import net.sf.freecol.common.model.FreeColGameObject;
-import net.sf.freecol.common.model.FreeColObject;
-import net.sf.freecol.common.model.Game;
-import net.sf.freecol.common.model.Goods;
-import net.sf.freecol.common.model.GoodsType;
-import net.sf.freecol.common.model.HighScore;
-import net.sf.freecol.common.model.IndianNationType;
-import net.sf.freecol.common.model.IndianSettlement;
-import net.sf.freecol.common.model.Location;
-import net.sf.freecol.common.model.ModelMessage;
-import net.sf.freecol.common.model.Monarch.MonarchAction;
-import net.sf.freecol.common.model.Nation;
-import net.sf.freecol.common.model.NationSummary;
-import net.sf.freecol.common.model.PathNode;
-import net.sf.freecol.common.model.Player;
-import net.sf.freecol.common.model.Settlement;
-import net.sf.freecol.common.model.Specification;
-import net.sf.freecol.common.model.Stance;
-import net.sf.freecol.common.model.StringTemplate;
-import net.sf.freecol.common.model.Tension;
-import net.sf.freecol.common.model.Tile;
-import net.sf.freecol.common.model.TileType;
-import net.sf.freecol.common.model.TradeRoute;
-import net.sf.freecol.common.model.TypeCountMap;
-import net.sf.freecol.common.model.Unit;
-import net.sf.freecol.common.model.UnitType;
-import net.sf.freecol.common.option.Option;
-import net.sf.freecol.common.option.OptionGroup;
-import net.sf.freecol.common.resources.ResourceManager;
 
 
 /**
@@ -2586,4 +2545,13 @@ public class GUI extends FreeColClientHolder {
      * Update all panels derived from the EuropePanel.
      */
     public void updateEuropeanSubpanels() {}
+
+    /**
+     * Show the mapAuthorshipDialog dialog.
+
+     * @return The selected map authorship as a {@code MapAuthorship}.
+     */
+    public MapDetails showMapDetailsDialog() {
+        return null;
+    }
 }

--- a/src/net/sf/freecol/client/gui/SwingGUI.java
+++ b/src/net/sf/freecol/client/gui/SwingGUI.java
@@ -19,23 +19,35 @@
 
 package net.sf.freecol.client.gui;
 
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.DisplayMode;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.HeadlessException;
-import java.awt.MouseInfo;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
+import net.sf.freecol.FreeCol;
+import net.sf.freecol.client.ClientOptions;
+import net.sf.freecol.client.FreeColClient;
+import net.sf.freecol.client.control.MapTransform;
+import net.sf.freecol.client.gui.animation.Animations;
+import net.sf.freecol.client.gui.dialog.FreeColDialog;
+import net.sf.freecol.common.model.MapDetails;
+import net.sf.freecol.client.gui.dialog.Parameters;
+import net.sf.freecol.client.gui.panel.*;
+import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
+import net.sf.freecol.client.gui.plaf.FreeColLookAndFeel;
+import net.sf.freecol.client.gui.video.VideoComponent;
+import net.sf.freecol.client.gui.video.VideoListener;
+import net.sf.freecol.common.FreeColException;
+import net.sf.freecol.common.i18n.Messages;
+import net.sf.freecol.common.metaserver.ServerInfo;
+import net.sf.freecol.common.model.*;
+import net.sf.freecol.common.model.Monarch.MonarchAction;
+import net.sf.freecol.common.option.LanguageOption;
+import net.sf.freecol.common.option.LanguageOption.Language;
+import net.sf.freecol.common.option.Option;
+import net.sf.freecol.common.option.OptionGroup;
+import net.sf.freecol.common.resources.Video;
+import net.sf.freecol.common.util.Introspector;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
 import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeEvent;
 import java.io.File;
@@ -44,72 +56,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 
-import javax.imageio.ImageIO;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JWindow;
-import javax.swing.Timer;
-
-import net.sf.freecol.FreeCol;
-import net.sf.freecol.client.ClientOptions;
-import net.sf.freecol.client.FreeColClient;
-import net.sf.freecol.client.control.MapTransform;
-import net.sf.freecol.client.gui.ImageLibrary;
-import net.sf.freecol.client.gui.animation.Animations;
-import net.sf.freecol.client.gui.dialog.CaptureGoodsDialog;
-import net.sf.freecol.client.gui.dialog.FreeColDialog;
-import net.sf.freecol.client.gui.dialog.Parameters;
-import net.sf.freecol.client.gui.panel.BuildQueuePanel;
-import net.sf.freecol.client.gui.panel.ColonyPanel;
-import net.sf.freecol.client.gui.panel.ColorChooserPanel;
-import net.sf.freecol.client.gui.panel.CornerMapControls;
-import net.sf.freecol.client.gui.panel.report.LabourData.UnitData;
-import net.sf.freecol.client.gui.panel.MapControls;
-import net.sf.freecol.client.gui.panel.TradeRouteInputPanel;
-import net.sf.freecol.client.gui.panel.Utility;
-import net.sf.freecol.client.gui.plaf.FreeColLookAndFeel;
-import net.sf.freecol.client.gui.video.VideoComponent;
-import net.sf.freecol.client.gui.video.VideoListener;
-import net.sf.freecol.common.FreeColException;
-import net.sf.freecol.common.i18n.Messages;
-import net.sf.freecol.common.metaserver.ServerInfo;
-import net.sf.freecol.common.model.Colony;
-import net.sf.freecol.common.model.Constants.IndianDemandAction;
-import net.sf.freecol.common.model.DiplomaticTrade;
-import net.sf.freecol.common.model.Europe;
-import net.sf.freecol.common.model.FoundingFather;
-import net.sf.freecol.common.model.FreeColGameObject;
-import net.sf.freecol.common.model.FreeColObject;
-import net.sf.freecol.common.model.Game;
-import net.sf.freecol.common.model.Goods;
-import net.sf.freecol.common.model.GoodsType;
-import net.sf.freecol.common.model.HighScore;
-import net.sf.freecol.common.model.IndianSettlement;
-import net.sf.freecol.common.model.Location;
-import net.sf.freecol.common.model.Map;
-import net.sf.freecol.common.model.ModelMessage;
-import net.sf.freecol.common.model.Monarch.MonarchAction;
-import net.sf.freecol.common.model.Nation;
-import net.sf.freecol.common.model.PathNode;
-import net.sf.freecol.common.model.Player;
-import net.sf.freecol.common.model.Settlement;
-import net.sf.freecol.common.model.Specification;
-import net.sf.freecol.common.model.StringTemplate;
-import net.sf.freecol.common.model.Tile;
-import net.sf.freecol.common.model.TileType;
-import net.sf.freecol.common.model.TradeRoute;
-import net.sf.freecol.common.model.TypeCountMap;
-import net.sf.freecol.common.model.Unit;
-import net.sf.freecol.common.model.UnitType;
-import net.sf.freecol.common.model.WorkLocation;
-import net.sf.freecol.common.option.BooleanOption;
-import net.sf.freecol.common.option.LanguageOption;
-import net.sf.freecol.common.option.LanguageOption.Language;
-import net.sf.freecol.common.option.Option;
-import net.sf.freecol.common.option.OptionGroup;
-import net.sf.freecol.common.resources.Video;
-import net.sf.freecol.common.util.Introspector;
-import static net.sf.freecol.common.util.StringUtils.*;
+import static net.sf.freecol.common.util.StringUtils.lastPart;
 
 
 /**
@@ -2072,5 +2019,13 @@ public class SwingGUI extends GUI {
     @Override
     public void updateEuropeanSubpanels() {
         canvas.updateEuropeanSubpanels();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MapDetails showMapDetailsDialog() {
+        return canvas.showMapDetailsDialog();
     }
 }

--- a/src/net/sf/freecol/client/gui/dialog/MapDetailsDialog.java
+++ b/src/net/sf/freecol/client/gui/dialog/MapDetailsDialog.java
@@ -1,0 +1,65 @@
+package net.sf.freecol.client.gui.dialog;
+
+import net.sf.freecol.client.FreeColClient;
+import net.sf.freecol.client.gui.panel.MigPanel;
+import net.sf.freecol.client.gui.panel.Utility;
+
+import javax.swing.*;
+
+import net.miginfocom.swing.MigLayout;
+import net.sf.freecol.common.model.MapDetails;
+
+/**
+ * A dialog for typing in the author and the description of the created map.
+ */
+public final class MapDetailsDialog extends FreeColInputDialog<MapDetails> {
+
+    private static final int COLUMNS = 5;
+    private static final int ROWS = 5;
+
+    /** The author name. */
+    private final JTextField authorName
+            = new JTextField(COLUMNS);
+
+    /** The map description. */
+    private final JTextArea mapDescription
+            = new JTextArea(ROWS, COLUMNS);
+
+    public MapDetailsDialog(FreeColClient freeColClient, JFrame frame) {
+        super(freeColClient, frame);
+
+        JLabel authorLabel = Utility.localizedLabel("name");
+        authorLabel.setLabelFor(authorName);
+
+        JLabel descriptionLabel = Utility.localizedLabel("description");
+        descriptionLabel.setLabelFor(mapDescription);
+
+        JPanel panel = new MigPanel(new MigLayout("wrap 2"));
+        panel.add(Utility.localizedHeader("mapAuthorshipDialog.mapAuthorship", true),
+                "span, align center");
+        panel.add(authorLabel, "newline 20");
+        panel.add(authorName);
+        panel.add(descriptionLabel);
+        panel.add(mapDescription);
+
+        initializeInputDialog(frame, true, panel, null, "ok", "cancel");
+    }
+
+    @Override
+    protected MapDetails getInputValue() {
+        String author, description;
+
+        author = authorName.getText();
+        description = mapDescription.getText();
+
+        return new MapDetails(author, description);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void requestFocus() {
+        this.authorName.requestFocus();
+    }
+}

--- a/src/net/sf/freecol/common/model/MapDetails.java
+++ b/src/net/sf/freecol/common/model/MapDetails.java
@@ -1,0 +1,13 @@
+package net.sf.freecol.common.model;
+
+public class MapDetails {
+
+    public final String authorName;
+
+    public final String mapDescription;
+
+    public MapDetails(String authorName, String mapDescription) {
+        this.authorName = authorName;
+        this.mapDescription = mapDescription;
+    }
+}


### PR DESCRIPTION
Currently, map creators can't save the author and a brief description of their maps as mentioned in the SourceForge forum thread https://sourceforge.net/p/freecol/improvement-requests/232/.

I created a little dialog that saves this information and then saves it in the XML document using a separate XML element. Here is a preview:

![image](https://user-images.githubusercontent.com/14187686/76691819-4dda1500-660c-11ea-9f0f-9a35ed584245.png)
