### PR TITLE
Simple move test case enhanced.

### DIFF
--- a/test/src/net/sf/freecol/client/control/MoveTest.java
+++ b/test/src/net/sf/freecol/client/control/MoveTest.java
@@ -70,8 +70,8 @@ public class MoveTest extends FreeColTestCase {
 
             client.getPreGameController().startGameHandler();
             assertEquals(plain1.getNeighbourOrNull(Direction.NE), plain2);
-            client.getInGameController().moveDirection(hardyPioneer,
-                    Direction.NE, false);
+            assertTrue(client.getInGameController().moveDirection(hardyPioneer,
+                    Direction.NE, false));
         } finally {
             if (client != null) {
                 ClientTestHelper.stopClient(client);

--- a/test/src/net/sf/freecol/client/gui/SaveDialogTest.java
+++ b/test/src/net/sf/freecol/client/gui/SaveDialogTest.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (C) 2002-2019  The FreeCol Team
+ *
+ *  This file is part of FreeCol.
+ *
+ *  FreeCol is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  FreeCol is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with FreeCol.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.sf.freecol.client.gui;
+
+import net.sf.freecol.util.test.FreeColTestCase;
+
+import java.awt.*;
+import java.io.File;
+import java.io.FileFilter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static net.sf.freecol.common.util.CollectionUtils.forEachMapEntry;
+
+
+public class SaveDialogTest extends FreeColTestCase {
+
+    public void testShowSaveDialog(){
+        File directory ;
+        String defaultName;
+
+
+    }
+}


### PR DESCRIPTION
The existing test case, testSimpleMove(), was not actually testing the movement. It merely tested whether or not tile 2 was in the direction.NE of tile1.

Added additional assertion statement to test if automatic movement (a.k.a. simple movement) occurs.
