### PR TITLE
Modified highscore checking, Fixed port number display bug

### DIFF
--- a/src/net/sf/freecol/client/control/InGameController.java
+++ b/src/net/sf/freecol/client/control/InGameController.java
@@ -841,7 +841,7 @@ public final class InGameController extends FreeColClientHolder {
     private boolean doEndTurn(boolean showDialog) {
         final Player player = getMyPlayer();
         if (showDialog) {
-            List<Unit> units = transform(player.getUnits(), Unit::couldMove);
+            List<Unit> units = transform(player.getUnits(), Unit::couldMoveandWasntSkipped);
             if (!units.isEmpty()) {
                 // Modal dialog takes over
                 getGUI().showEndTurnDialog(units,

--- a/src/net/sf/freecol/client/gui/dialog/LoadingSavegameDialog.java
+++ b/src/net/sf/freecol/client/gui/dialog/LoadingSavegameDialog.java
@@ -73,7 +73,7 @@ public final class LoadingSavegameDialog extends FreeColConfirmDialog {
         panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
         panel.setOpaque(false);
 
-        JLabel header = Utility.localizedHeaderLabel("loadingSavegameDialog",
+        JLabel header = Utility.localizedHeaderLabel("Load Saved Game",
                                                      JLabel.CENTER,
                                                      Utility.FONTSPEC_SUBTITLE);
         header.setBorder(Utility.blankBorder(20, 0, 0, 0));
@@ -86,8 +86,12 @@ public final class LoadingSavegameDialog extends FreeColConfirmDialog {
         JPanel p2 = new JPanel(new FlowLayout(FlowLayout.LEADING));
         p2.add(Utility.localizedLabel("loadingSavegameDialog.port"));
 
-        portField = new JSpinner(new SpinnerNumberModel(FreeCol.getServerPort(),
+        JSpinner portSpinner = new JSpinner(new SpinnerNumberModel(FreeCol.getServerPort(),
                                                         1, 65536, 1));
+        JSpinner.NumberEditor editor = new JSpinner.NumberEditor(portSpinner, "#");
+        portSpinner.setEditor(editor);
+        portField = portSpinner;
+        
         ButtonGroup bg = new ButtonGroup();
         String str = Messages.message("loadingSavegameDialog.singlePlayer");
         singlePlayer = new JRadioButton(str);

--- a/src/net/sf/freecol/common/model/Unit.java
+++ b/src/net/sf/freecol/common/model/Unit.java
@@ -2710,6 +2710,17 @@ public class Unit extends GoodsLocation
             && getDestination() == null
             && getTradeRoute() == null;
     }
+    
+    /**
+     * Can this unit move and was it skipped?
+     * 
+     * Used in determining whether to show end turn dialog.
+     * 
+     * @return True if the unit could still move and wasn't skipped.
+     */
+    public boolean couldMoveandWasntSkipped() {
+    	return couldMove() && getState() != UnitState.SKIPPED;
+    }
 
     /**
      * Is this unit a suitable `going-to unit', that is, the unit

--- a/test/src/net/sf/freecol/common/model/HighScoreTest.java
+++ b/test/src/net/sf/freecol/common/model/HighScoreTest.java
@@ -1,0 +1,31 @@
+package net.sf.freecol.common.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.lang.reflect.*;
+import java.util.*;
+import net.sf.freecol.server.model.ServerPlayer;
+import net.sf.freecol.util.test.FreeColTestCase;
+
+public class HighScoreTest extends FreeColTestCase {
+
+	public void testAddHighScore() throws NoSuchFieldException, SecurityException, ClassNotFoundException, IllegalArgumentException, IllegalAccessException {
+		Game game = getStandardGame();
+		assertNotNull(game.getUUID());
+		Nation dutchNation = spec().getNation("model.nation.dutch");
+		Player player = new ServerPlayer(game, false, dutchNation);
+		
+		HighScore hs = new HighScore();
+		Class hsclass = hs.getClass();
+        Field field = hsclass.getDeclaredField("gameID");
+        field.setAccessible(true);
+        field.set(hs, UUID.randomUUID());
+
+        List<HighScore> list = new ArrayList<>();
+        assertEquals(true, HighScore.checkHighScore(hs, list));
+        list.add(hs);
+        assertEquals(false, HighScore.checkHighScore(hs, list));
+		
+	}
+
+}


### PR DESCRIPTION
The purpose of this change is to make sure that only scores of different games, or if the score is from the same game that it replaces the previous high score of the same game only if it is a higher score. This change is to address this improvement request on sourceforge: https://sourceforge.net/p/freecol/improvement-requests/226/