### PR TITLE
Be able to open Trade Routes from menu

### DIFF
--- a/src/net/sf/freecol/client/gui/SwingGUI.java
+++ b/src/net/sf/freecol/client/gui/SwingGUI.java
@@ -2310,7 +2310,7 @@ public class SwingGUI extends GUI {
     @Override
     public FreeColPanel showTradeRoutePanel(Unit unit) {
         return this.widgets.showTradeRoutePanel(unit,
-            getPopupPosition(unit.getTile()));
+            getPopupPosition((unit == null) ? null : unit.getTile()));
     }
 
     /**


### PR DESCRIPTION
Make possible to open Trade Routes panel from menu (when unit parameter is null).
It's a fix for: https://sourceforge.net/p/freecol/bugs/3218/