### PR TITLE
Order colony-resources from best to worst in workplan

### DIFF
--- a/src/net/sf/freecol/server/ai/ColonyPlan.java
+++ b/src/net/sf/freecol/server/ai/ColonyPlan.java
@@ -871,8 +871,11 @@ public class ColonyPlan {
                     int i = produce.indexOf(gt);
                     return (i < 0 && !gt.isFoodType()) ? 99999 : i;
                 })
-            .thenComparingInt((WorkLocationPlan wp) ->
-                wp.getWorkLocation().getGenericPotential(wp.getGoodsType()))
+            // Should be in reverse order (highest value first)
+            .thenComparingInt((WorkLocationPlan wp) -> {
+                return wp.getWorkLocation().getGenericPotential(wp.getGoodsType()) * -1;
+                })
+
             .thenComparing(WorkLocationPlan::getGoodsType,
                            GoodsType.goodsTypeComparator);
         workPlans.sort(comp);
@@ -1485,6 +1488,7 @@ plans:          for (WorkLocationPlan w : getFoodPlans()) {
             " ", colony.getTile(),
             "\nProfile: ", profileType, "\nPreferred production:");
         FreeColObject.logFreeColObjects(getPreferredProduction(), lb);
+        lb.add("\n");
         lb.add(getBuildableReport(), "Food Plans:\n");
         for (WorkLocationPlan wlp : getFoodPlans()) {
             WorkLocation wl = wlp.getWorkLocation();


### PR DESCRIPTION
Sometimes AI assigns European units to worst producing tile.

I think the bug is caused by a wrongly sorted workplan in ColonyPlan.java.