### PR TITLE
Change sign of goods due to mixup buy/sell

### DIFF
--- a/src/net/sf/freecol/client/control/InGameController.java
+++ b/src/net/sf/freecol/client/control/InGameController.java
@@ -3183,7 +3183,11 @@ public final class InGameController extends FreeColClientHolder {
         if (ret) {
             if (colonyWas != null) colonyWas.fireChanges();
             if (europeWas != null) europeWas.fireChanges();
-            if (marketWas != null) marketWas.fireChanges(req);
+            if (marketWas != null) {
+            	// Change sign due to mixup buy/sell
+            	for (AbstractGoods ag : req) ag.setAmount(-ag.getAmount());
+            	marketWas.fireChanges(req);
+            }
             unitWas.fireChanges();
             updateGUI(null, false);
         }


### PR DESCRIPTION
There is a mixup of buy/sell when a unit is equiped with tools in Europe.

See attached before screen-shot:
![bug_before](https://user-images.githubusercontent.com/32073147/106184639-1d5a8580-61a2-11eb-8c8f-d69f34f3408e.png)

And the after screen-shot:
![bug_after](https://user-images.githubusercontent.com/32073147/106184677-29dede00-61a2-11eb-8f81-46f3f4bb38b5.png)

This a purchase of tools.
The total amount of gold is decreased correct, However, the _purchase_ is recorded as a _sell_. (and vice versa for drop tools)

To recreate:

In Europe:
- purchase or train unit
- left click unit
- select "Equip with tools"

Note: This fix need to be reviewed - it fixes the issue, but is it the right way to fix it? I may be wrong but usually a buy is a negative number, but sometimes not.  