### PR TITLE
Fix illegal component position exception in addToCanvas

### DIFF
--- a/src/net/sf/freecol/client/gui/Canvas.java
+++ b/src/net/sf/freecol/client/gui/Canvas.java
@@ -369,6 +369,8 @@ public final class Canvas extends JDesktopPane {
      */
     private void addToCanvas(Component comp, Integer layer) {
         try {
+        	// To avoid illegal component position exception - remove the component first
+            remove(comp);
             add(comp, layer);
         } catch (Exception e) {
             logger.log(Level.WARNING, "addToCanvas("


### PR DESCRIPTION
For me the log fills with stacktraces of illegal component position exception when debugging.

This is a simple fix for that.