### PR TITLE
Mark as single window application in .desktop file 

### DIFF
--- a/packaging/common/freecol.desktop
+++ b/packaging/common/freecol.desktop
@@ -8,3 +8,4 @@ TryExec=/usr/bin/freecol
 Exec=freecol
 Icon=/usr/share/pixmaps/freecol.xpm
 Categories=Game;StrategyGame;
+SingleMainWindow=true


### PR DESCRIPTION
SingleMainWindow is a standard .desktop entry key signaling that an app only
supports having a single instance of its main window open.

See https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
