### PR TITLE
improve compact colony report

### DIFF
--- a/data/strings/FreeColMessages.properties
+++ b/data/strings/FreeColMessages.properties
@@ -3222,7 +3222,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% are being
 report.colony.production.header=Net %goods% production
 report.colony.production.high.description=%colony%: %amount% %goods% are being produced, full {{plural:%turns%|one=next turn|other=in %turns% turns}}
 report.colony.production.low.description=%colony%: %amount% %goods% are being consumed, gone {{plural:%turns%|one=next turn|other=in %turns% turns}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% are being consumed (could consume %more% more)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% are being produced (could produce %more% more)
 report.colony.production.summary.description=The amount of goods being produced or consumed
 report.colony.production.waste.description=%colony%: %amount% %goods% are being produced, warehouse will overflow, %waste% will be wasted

--- a/data/strings/FreeColMessages.properties
+++ b/data/strings/FreeColMessages.properties
@@ -3190,6 +3190,8 @@ report.colony.annotation.unfortified=Unfortified
 report.colony.arriving.description=%colony%: new %unit% {{plural:%turns%|one=next turn|other=in %turns% turns}}
 report.colony.arriving.summary.description=The average number of turns before a new colonist arrives in the colonies of this continent
 report.colony.birth.description=Number of turns until a new colonist arrives or starves
+report.colony.notWorking.description=Number of units not working
+report.colony.notWorkingInProfession.description=Number of units not working in their profession
 report.colony.explore.description=Number of tiles to Explore adjacent to this colony
 report.colony.explore.header=E
 report.colony.exploring.description=%colony% would benefit from exploring {{plural:%amount%|one=one tile|other=%amount% tiles}}

--- a/data/strings/FreeColMessages_ar.properties
+++ b/data/strings/FreeColMessages_ar.properties
@@ -2759,7 +2759,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% يتم إ
 report.colony.production.header=صافي إنتاج %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% يتم إنتاجها، {{plural:%turns%|one=الدور القادم الكامل|other=في الأدوار الكاملة %turns%}}
 report.colony.production.low.description=%colony%: %amount% %goods% يتم استهلاكها، ضاع {{plural:%turns%|one=الدور القادم|other=في الأدوار %turns%}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% يتم استهلاكها (يمكن أن تستهلك %more% أكثر)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% يتم إنتاجها (يمكن أن تنتج %more% أكثر)
 report.colony.production.summary.description=كمية البضائع التي يتم إنتاجها أو استهلاكها
 report.colony.production.waste.description=%colony%: %amount% %goods% يتم إنتاجها، المستودع سوف يفيض، %waste% سوف تضيع

--- a/data/strings/FreeColMessages_be-tarask.properties
+++ b/data/strings/FreeColMessages_be-tarask.properties
@@ -2701,7 +2701,6 @@ report.colony.production.export.description=%colony%: вырабляецца %am
 report.colony.production.header=Агульная вытворчасьць %goods%
 report.colony.production.high.description=%colony%: выпускаецца %amount% %goods%, максымум будзе дасягнуты {{plural:%turns%|one=на наступным ходзе|few=праз %turns% хады|many=праз %turns% хадоў}}
 report.colony.production.low.description=%colony%: спажываецца %amount% %goods%, вычарпаюцца {{plural:%turns%|one=на наступным ходзе|few=праз %turns% хады|many=праз %turns% хадоў}}
-report.colony.production.maxConsumption.description=%colony%: спажываецца %amount% %goods% (можа спажываць на %more% болей)
 report.colony.production.maxProduction.description=%colony%: выпускаецца %amount% %goods% (можа выпускацца на %more% больш)
 report.colony.production.summary.description=Колькасьць тавараў, якія выпускаюцца або спажываюцца
 report.colony.production.waste.description=%colony%: вырабляецца %amount% %goods%, сховішча будзе перапоўненае, %waste% будзе страчана

--- a/data/strings/FreeColMessages_br.properties
+++ b/data/strings/FreeColMessages_br.properties
@@ -2759,7 +2759,6 @@ report.colony.production.export.description=%colony% : %amount% eus %goods% zo p
 report.colony.production.header=Produadur rik a %goods%
 report.colony.production.high.description=%colony% : produadur rik a %goods% = %amount%, aet da netra {{plural:%turns%|one=kentañ tro|other=a-benn %turns% tro}}
 report.colony.production.low.description=%colony% : %amount% a %goods% bevezet, a vo goullo {{plural:%turns%|one=kentañ tro|other=a-benn %turns% tro}}
-report.colony.production.maxConsumption.description=%colony% : bevezet eo bet %amount% a %goods% (%more% ouzhpenn a c'hall bezañ bevezet)
 report.colony.production.maxProduction.description=%colony% : produet ez eus %amount% a %goods% (%more% ouzhpenn a c'hallje bezañ)
 report.colony.production.summary.description=Sammad ar varc'hadourezh produet pe vevezet
 report.colony.production.waste.description=%colony%:%amount% %goods% zo bet produet. Leun-chouk eo ar sanailh, %waste% a vo kollet.

--- a/data/strings/FreeColMessages_ca.properties
+++ b/data/strings/FreeColMessages_ca.properties
@@ -2856,7 +2856,6 @@ report.colony.production.export.description=%colony%: es produeixen %amount% %go
 report.colony.production.header=Producció neta de %goods%
 report.colony.production.high.description=%colony%: es produeixen %amount% %goods%, ple {{plural:en %turns%|one=al proper torn|other=en %turns% torns}}
 report.colony.production.low.description=%colony%: es consumeixen %amount% %goods%, buit {{plural:en %turns%|one=el proper torn|other=en %turns% torns}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% estan sent consumides (se'n poden consumir %more% més)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% estan sent produïts (se'n poden produir %more% més)
 report.colony.production.summary.description=La quantitat de productes que es produeixen o consumeixen
 report.colony.production.waste.description=%colony%: es produeixen %amount% %goods%, el magatzem es desbordarà i es malgastaran %waste%

--- a/data/strings/FreeColMessages_cs_CZ.properties
+++ b/data/strings/FreeColMessages_cs_CZ.properties
@@ -2790,7 +2790,6 @@ report.colony.production.export.description=%colony%: je vyprodukováno %amount%
 report.colony.production.header=Čistá produkce %goods%
 report.colony.production.high.description=%colony%: vyrábí se %amount% ks %goods%, zaplní se {{plural:%turns%|one=příští tah|other=za %turns% tahů}}
 report.colony.production.low.description=%colony%: %amount% ks %goods% bude spotřebováno {{plural:%turns%|one=příští tah|other=za %turns% tahů}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% je spotřebováno (mohlo by být spotřebováno o %more% více)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% je vyprodukováno (mohlo by být vyprodukováno o %more% více)
 report.colony.production.summary.description=Množství zboží, které je vyrobeno nebo spotřebováno
 report.colony.production.waste.description=%colony%: je vyprodukováno %amount% ks %goods%, kapacita skladiště bude překročena a %waste% ks %goods% bude ztraceno

--- a/data/strings/FreeColMessages_da.properties
+++ b/data/strings/FreeColMessages_da.properties
@@ -2768,7 +2768,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% er under 
 report.colony.production.header=Nettoproduktion af %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% er under fremstilling, færdig {{plural:%turns%|one=i næste tur|other=om %turns% ture}}
 report.colony.production.low.description=%colony%: %amount% %goods% forbruges, væk {{plural:%turns%|one=i næste tur|other=om %turns% ture}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% forbruges (kan forbruge %more% yderligere)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% fremstilles (kunne fremstille %more% yderligere)
 report.colony.production.summary.description=Mængden af varer under fremstilling eller forbrug
 report.colony.production.waste.description=%colony%: %amount% %goods% er under fremstilling, lageret vil blive overfyldt, %waste% vil blive kasseret

--- a/data/strings/FreeColMessages_de.properties
+++ b/data/strings/FreeColMessages_de.properties
@@ -2751,7 +2751,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% werden pr
 report.colony.production.header=%goods% Produktion (netto)
 report.colony.production.high.description=%colony%: %amount% %goods% werden produziert, voll bis {{plural:%turns%|one=nächster Runde|other=in %turns% Runden}}
 report.colony.production.low.description=%colony%: %amount% %goods% werden konsumiert, leer bis {{plural:%turns%|one=nächster Runde|other=in %turns% Runden}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% werden konsumiert (könnte weitere %more% konsumieren)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% werden produziert (könnte weitere %more% produzieren)
 report.colony.production.summary.description=Die Menge an Gütern, die produziert oder konsumiert wird.
 report.colony.production.waste.description=%colony%: %amount% %goods% werden produziert, Lagerhaus quillt über, %waste% wird verschwendet

--- a/data/strings/FreeColMessages_fr.properties
+++ b/data/strings/FreeColMessages_fr.properties
@@ -2919,7 +2919,6 @@ report.colony.production.export.description=%colony% : %amount% de %goods% sont 
 report.colony.production.header=Production nette de %goods%
 report.colony.production.high.description=%colony% : %amount% de %goods% sont produit(e)s, sera pleine {{plural:%turns%|one=le prochain tour|other=dans %turns% tours}}
 report.colony.production.low.description=%colony% : %amount% de %goods% consommé(e)s, sera vide {{plural:%turns%|one=le prochain tour|other=dans %turns% tours}}
-report.colony.production.maxConsumption.description=%colony% : %amount% de %goods% sont consommé(e)s (peut en consommer %more% de plus)
 report.colony.production.maxProduction.description=%colony% : %amount% de %goods% sont produit(e)s (%more% de plus pourraient l’être)
 report.colony.production.summary.description=La quantité de marchandises produite ou consommée
 report.colony.production.waste.description=%colony% : %amount% de %goods% sont produit(e)s, l’entrepôt va déborder, %waste% seront perdu(e)s

--- a/data/strings/FreeColMessages_ie.properties
+++ b/data/strings/FreeColMessages_ie.properties
@@ -2668,7 +2668,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% es sub pr
 report.colony.production.header=Netto production de %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% es sub production, plen {{plural:%turns%|one=in li sequent torn|other=pos %turns% tornes}}
 report.colony.production.low.description=%colony%: on consumpte %amount% %goods%, a desaparir {{plural:%turns%|one=in li sequent torn|other=pos %turns% tornes}}
-report.colony.production.maxConsumption.description=%colony%: on consumpte %amount% %goods% (possibilmen %more% plu)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% es sub production (possibilmen %more% plu)
 report.colony.production.summary.description=Li quantitá de merces essent productet o consumptet
 report.colony.production.waste.description=%colony%: %amount% %goods% es sub production, magasine va superfluar, %waste% va esser spoliat

--- a/data/strings/FreeColMessages_lt.properties
+++ b/data/strings/FreeColMessages_lt.properties
@@ -2568,7 +2568,6 @@ report.colony.production.description=%colony%: yra gaminama %amount% %goods%
 report.colony.production.export.description=%colony%: yra gaminama %amount% %goods% (eksportas virš %export%)
 report.colony.production.high.description=%colony%: yra gaminama %amount% %goods%, pilna {{plural:%turns%|one=kitą ėjimą|other=už %turns% ėjimų}}
 report.colony.production.low.description=%colony%: yra naudojama %amount% %goods%, nebebus {{plural:%turns%|one=kitą ėjimą|other=už %turns% ėjimų}}
-report.colony.production.maxConsumption.description=%colony%: yra naudojama %amount% %goods% (gali būti vartojama dar %more%)
 report.colony.production.maxProduction.description=%colony%: yra gaminama %amount% %goods% (gali gaminti dar %more%)
 report.colony.production.summary.description=Prekių kiekis, kuris yra pagaminamas ar suvartojamas
 report.colony.production.waste.description=%colony%: yra gaminama %amount% %goods%, sandėlis bus perpildytas, bus iššvaistyta %waste%.

--- a/data/strings/FreeColMessages_nl.properties
+++ b/data/strings/FreeColMessages_nl.properties
@@ -2825,7 +2825,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% worden ge
 report.colony.production.header=Netto productie van %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% worden geproduceerd, vol {{plural:%turns%|one=in de volgende beurt|other=over %turns% beurten}}
 report.colony.production.low.description=%colony%: %amount% %goods% worden geconsumeerd, op {{plural:%turns%|one=in volgende beurt|other=over %turns% beurten}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% worden geconsumeerd (kunnen %more% meer consumeren)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% worden geproduceerd (kunnen %more% meer produceren)
 report.colony.production.summary.description=De hoeveelheid goederen die wordt geproduceerd of geconsumeerd
 report.colony.production.waste.description=%colony%: %amount% %goods% worden geproduceerd, het pakhuis knalt uit zijn voegen, er gaat %waste% verloren

--- a/data/strings/FreeColMessages_pms.properties
+++ b/data/strings/FreeColMessages_pms.properties
@@ -2746,7 +2746,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% a son pro
 report.colony.production.header=Produssion polida ëd %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% a son produvù, a sarà pien-a {{plural:%turns%|one=ël tor ch'a-i ven|other=da-sì %turns% tor}}
 report.colony.production.low.description=%colony%: %amount% %goods% a son consumà, a sarà veuida {{plural:%turns%|one=ël tor ch'a-i ven|other=da-sì %turns% tor}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% a son consumà (a podrìa consumene %more% ëd pi)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% a son produvù (a podrìa produv-ne %more% ëd pi)
 report.colony.production.summary.description=La quantità ëd mërcansìe produvùe o consumà
 report.colony.production.waste.description=%colony%: %amount% %goods% a s on prodot, ël magasin a debordërà, %waste% a saran ësgheirà

--- a/data/strings/FreeColMessages_pt_BR.properties
+++ b/data/strings/FreeColMessages_pt_BR.properties
@@ -2771,7 +2771,6 @@ report.colony.production.export.description=%colony%: está a produzir %amount% 
 report.colony.production.header=Produção líquida de %goods%
 report.colony.production.high.description=%colony%: está a produzir %amount% %goods%, ficará cheia {{plural:%turns%|one=na próxima jogada|other=daqui a %turns% jogadas}}
 report.colony.production.low.description=%colony%: está a consumir %amount% %goods%, ficará vazia {{plural:%turns%|one=na próxima jogada|other=daqui a %turns% jogadas}}
-report.colony.production.maxConsumption.description=%colony%: está a consumir %amount% %goods% (podia consumir mais %more%)
 report.colony.production.maxProduction.description=%colony%: está a produzir %amount% %goods% (podia produzir mais %more%)
 report.colony.production.summary.description=A quantidade de bens que estão sendo produzidos ou consumidos
 report.colony.production.waste.description=%colony%: está a produzir %amount% %goods%, o armazém ficará sobrecarregado, desperdiçará %waste%

--- a/data/strings/FreeColMessages_pt_PT.properties
+++ b/data/strings/FreeColMessages_pt_PT.properties
@@ -2790,7 +2790,6 @@ report.colony.production.export.description=%colony%: está a produzir %amount% 
 report.colony.production.header=Produção líquida de %goods%
 report.colony.production.high.description=%colony%: está a produzir %amount% %goods%, ficará cheia {{plural:%turns%|one=na próxima jogada|other=daqui a %turns% jogadas}}
 report.colony.production.low.description=%colony%: está a consumir %amount% %goods%, ficará vazia {{plural:%turns%|one=na próxima jogada|other=daqui a %turns% jogadas}}
-report.colony.production.maxConsumption.description=%colony%: está a consumir %amount% %goods% (podia consumir mais %more%)
 report.colony.production.maxProduction.description=%colony%: está a produzir %amount% %goods% (podia produzir mais %more%)
 report.colony.production.summary.description=A quantidade de mercadorias que estão a ser produzidas ou consumidas
 report.colony.production.waste.description=%colony%: está a produzir %amount% %goods%, o armazém ficará sobrecarregado, desperdiçará %waste%

--- a/data/strings/FreeColMessages_ru.properties
+++ b/data/strings/FreeColMessages_ru.properties
@@ -2892,7 +2892,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% объё�
 report.colony.production.header=Объём производства товара %goods%
 report.colony.production.high.description=%colony%: %amount% %goods% объём производства, достигнет максимума через %turns% {{plural:%turns%|one=ход|few=хода|many=ходов}}
 report.colony.production.low.description=%colony%: %amount% %goods% остаток товара, будет исчерпан через %turns% {{plural:%turns%|one=ход|few=хода|many=ходов}}
-report.colony.production.maxConsumption.description=%colony%: Потребляемое количество %amount% %goods% (может потреблять еще %more% )
 report.colony.production.maxProduction.description=%colony%: Производимое количество %amount% %goods% (может производить еще %more% )
 report.colony.production.summary.description=Количество производимых или потребляемых товаров
 report.colony.production.waste.description=%colony%: %amount% %goods% масса нетто произведенного товара, склад переполнен, %waste% будет утилизирован

--- a/data/strings/FreeColMessages_sk.properties
+++ b/data/strings/FreeColMessages_sk.properties
@@ -2706,7 +2706,6 @@ report.colony.production.export.description=%colony%: Vyrába sa %amount% ks tov
 report.colony.production.header=Čistá výroba tovaru %goods%
 report.colony.production.high.description=%colony%: Vyrába sa %amount% ks tovaru %goods%, plno {{plural:%turns%|one=za jedenťah|two=za dva ťahy|three=za tri ťahy|four=za štyri ťahy|other=za %turns% ťahov}}
 report.colony.production.low.description=%colony%: Spotrebúva sa %amount% ks tovaru %goods%, úplne sa minie {{plural:%turns%|one=za jeden ťah|two=za dva ťahy|three=za tri ťahy|four=za štyri ťahy|other=za %turns% ťahov}}
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% sa spotrebováva (mohlo by byť spotrebovaných o %more% viac)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% je vyrábaných (môže sa vyrábať o %more% viac)
 report.colony.production.summary.description=Množstvo tovarov, ktoré sú vyrábané alebo spotrebovávané
 report.colony.production.waste.description=%colony%: Vyrába sa %amount% ks tovaru %goods% , sklad bude preplnený, %waste% ks bude vyhodených

--- a/data/strings/FreeColMessages_tr.properties
+++ b/data/strings/FreeColMessages_tr.properties
@@ -2718,7 +2718,6 @@ report.colony.production.export.description=%colony%: %amount% %goods% üretiliy
 report.colony.production.header=Net %goods% üretim
 report.colony.production.high.description=%colony%: %amount% %goods% üretiliyor, {{plural:%turns%|one=sonraki dönüş|other=%turns% dönüş}} dolu
 report.colony.production.low.description=%colony%: %amount% %goods% tüketiliyor, gone {{plural:%turns%|one=sonraki dönüş|other=%turns% dönüş}} gitti
-report.colony.production.maxConsumption.description=%colony%: %amount% %goods% tüketiliyor (%more% daha fazla tüketebilir)
 report.colony.production.maxProduction.description=%colony%: %amount% %goods% üretiliyor (%more% daha fazla üretebilir)
 report.colony.production.summary.description=Üretilen veya tüketilen mal miktarı
 report.colony.production.waste.description=%colony%: %amount% %goods% üretiliyor, depo taşacak, %waste% boşa gidecek

--- a/data/strings/FreeColMessages_uk.properties
+++ b/data/strings/FreeColMessages_uk.properties
@@ -2806,7 +2806,6 @@ report.colony.production.export.description=%colony%: вироблено %amount
 report.colony.production.header=Маса нетто виготовлених %goods%
 report.colony.production.high.description=%colony%: виготовлено %amount% %goods%, буде заповнено {{plural:%turns%|one=наступного ходу|other=за %turns% ходів}}
 report.colony.production.low.description=%colony%: буде спожито %goods% = %amount%, вичерпається {{plural:%turns%|one=в наступному ході|other=за %turns% ходів}}
-report.colony.production.maxConsumption.description=%colony%: споживається %amount% %goods% (може спожити %more% більше)
 report.colony.production.maxProduction.description=%colony%: виробляється %amount% %goods% (може вироблятися на %more% більше)
 report.colony.production.summary.description=Кількість товарів, які виробляються або споживаються
 report.colony.production.waste.description=%colony%: виробляється %amount% %goods%, склад буде переповнено, %waste% змарнується

--- a/data/strings/FreeColMessages_zh-hant.properties
+++ b/data/strings/FreeColMessages_zh-hant.properties
@@ -2726,7 +2726,6 @@ report.colony.production.export.description=%colony%：已生產 %amount% 個 %g
 report.colony.production.header=%goods% 淨產量
 report.colony.production.high.description=%colony%: %amount% 個 %goods% 生產中，將滿足{{plural:%turns%|one=下一回合|other=%turns% 回合後}}的需求。
 report.colony.production.low.description=%colony%: %amount% 個 %goods% 消耗中，將在{{plural:%turns%|one=下一回合|other=%turns% 回合後}}消耗殆盡。
-report.colony.production.maxConsumption.description=%colony%：%amount% 個 %goods% 消耗中（可以再消耗 %more%）
 report.colony.production.maxProduction.description=%colony%：%amount% 個 %goods% 生產中（可以再製造 %more%）
 report.colony.production.summary.description=生產或消費的貨物量
 report.colony.production.waste.description=%colony%：正在生產 %amount% 個 %goods%。倉庫將滿並將浪費 %waste%

--- a/data/strings/FreeColMessages_zh_CN.properties
+++ b/data/strings/FreeColMessages_zh_CN.properties
@@ -2823,7 +2823,6 @@ report.colony.production.export.description=%colony%：%amount% %goods%已生产
 report.colony.production.header=%goods%净产量
 report.colony.production.high.description=%colony%：已制造%amount%个%goods%，满足{{plural:%turns%|one=下一回合|other=接下来%turns%回合}}的需求
 report.colony.production.low.description=%colony%：已消耗%amount%个%goods%，{{plural:%turns%|one=下一回合|other=%turns%回合后}}将消耗殆尽
-report.colony.production.maxConsumption.description=%colony%：%amount% 殖民地货物数量 %goods% 正在被消耗（可以被消耗 %more%更多）
 report.colony.production.maxProduction.description=%colony%：%amount% 殖民地货物数量 %goods% 正在被生产（可以被生产 %more%更多）
 report.colony.production.summary.description=货物正在生产或者消耗掉数量
 report.colony.production.waste.description=%colony%：%amount% %goods% 正在生产，仓库将溢出，%waste% 将被浪费

--- a/src/net/sf/freecol/client/gui/panel/report/ReportCompactColonyPanel.java
+++ b/src/net/sf/freecol/client/gui/panel/report/ReportCompactColonyPanel.java
@@ -700,7 +700,7 @@ public final class ReportCompactColonyPanel extends ReportPanel {
         long n = getAllUnits(s)
                 .filter(u -> u.isPerson() && u.isExpertWorkingAsSomethingElse())
                 .count();
-        reportPanel.add((n == 0) ? new JLabel() : newButton(colonyId, Long.toString(n), null, cWarn, stpld("report.colony.notWorkingInProfession")));
+        reportPanel.add((n == 0) ? new JLabel() : newButton(colonyId, Long.toString(n), null, cAlarm, stpld("report.colony.notWorkingInProfession")));
     }
 
     private Stream<Unit> getAllUnits(ColonySummary s) {

--- a/src/net/sf/freecol/client/gui/panel/report/ReportCompactColonyPanel.java
+++ b/src/net/sf/freecol/client/gui/panel/report/ReportCompactColonyPanel.java
@@ -682,11 +682,15 @@ public final class ReportCompactColonyPanel extends ReportPanel {
         if (!unit.isPerson()) {
             return true;
         }
-        if (unit.isInColony()) {
-            return unit.getWorkType() != null || unit.getStudent() != null;
-        } else {
-            return unit.getRole().getId().equals("model.role.soldier");
+        switch (unit.getState()) {
+            case FORTIFIED:
+            case FORTIFYING:
+            case IMPROVING:
+                return true;
+            case IN_COLONY:
+                return unit.getWorkType() != null || unit.getStudent() != null;
         }
+        return unit.getRole().getRequiredGoodsList().stream().anyMatch(g -> g.getId().equals("model.goods.muskets"));
     }
 
     private void addNotWorking(ColonySummary s, String colonyId) {

--- a/src/net/sf/freecol/common/model/BuildingType.java
+++ b/src/net/sf/freecol/common/model/BuildingType.java
@@ -19,19 +19,20 @@
 
 package net.sf.freecol.common.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.swing.JList;
-import javax.swing.ListModel;
-import javax.xml.stream.XMLStreamException;
-
 import net.sf.freecol.common.io.FreeColXMLReader;
 import net.sf.freecol.common.io.FreeColXMLWriter;
 import net.sf.freecol.common.model.Colony.NoBuildReason;
-import static net.sf.freecol.common.model.Constants.*;
 import net.sf.freecol.common.model.UnitLocation.NoAddReason;
-import static net.sf.freecol.common.util.CollectionUtils.*;
+
+import javax.swing.*;
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.sf.freecol.common.model.Constants.INFINITY;
+import static net.sf.freecol.common.model.Constants.UNDEFINED;
+import static net.sf.freecol.common.util.CollectionUtils.first;
+import static net.sf.freecol.common.util.CollectionUtils.transform;
 
 
 /**
@@ -249,10 +250,10 @@ public final class BuildingType extends BuildableType
      *
      * @return The {@code ProductionType} list.
      */
-    protected List<ProductionType> getProductionTypes() {
+    public List<ProductionType>getProductionTypes() {
         return this.productionTypes;
     }
-    
+
     /**
      * Set the production type list.
      *
@@ -484,7 +485,7 @@ public final class BuildingType extends BuildableType
         this.rebelFactor = o.getRebelFactor();
         this.upgradesFrom = o.getUpgradesFrom();
         this.upgradesTo = o.getUpgradesTo();
-        this.setProductionTypes(o.getProductionTypes());        
+        this.setProductionTypes(o.getProductionTypes());
         return true;
     }
 

--- a/src/net/sf/freecol/common/model/Unit.java
+++ b/src/net/sf/freecol/common/model/Unit.java
@@ -3918,18 +3918,16 @@ public class Unit extends GoodsLocation
     }
 
     /**
-     * Is this unit is a person that is an expert, but works as something else.
-     *
-     * @return True if this unit is a non-expert worker.
+     * Is this unit is working in their profession, if it has any.
      */
-    public boolean isExpertWorkingAsSomethingElse() {
-        if (getStudent() != null) {
-            return false;
-        }
+    public boolean isWorkingInProfession() {
         if (getRole().getRequiredGoodsList().stream().anyMatch(g -> g.getId().equals("model.goods.muskets"))) {
-            return !hasAbility(Ability.EXPERT_SOLDIER);
+            return hasAbility(Ability.EXPERT_SOLDIER);
         }
-        return getType().getExpertProduction() != null && isInColony() && nonExpertWorker(getWorkType());
+        return getType().getExpertProduction() == null
+               || !isInColony()
+               || !nonExpertWorker(getWorkType())
+               || getStudent() != null;
     }
 
     /**

--- a/src/net/sf/freecol/common/model/Unit.java
+++ b/src/net/sf/freecol/common/model/Unit.java
@@ -3926,7 +3926,7 @@ public class Unit extends GoodsLocation
         if (getStudent() != null) {
             return false;
         }
-        if (getRole().getId().equals("model.role.soldier")) {
+        if (getRole().getRequiredGoodsList().stream().anyMatch(g -> g.getId().equals("model.goods.muskets"))) {
             return !hasAbility(Ability.EXPERT_SOLDIER);
         }
         return getType().getExpertProduction() != null && isInColony() && nonExpertWorker(getWorkType());


### PR DESCRIPTION
- show good production in blue (i.e. good) if all required buildings are built (including factories, even if factories are not available yet)
- show bells and hammers, too - this makes it easier to see 
  - if all buildings are built (see above)
  - if there is a production warning for hammers - this should have worked by showing underconsumption for lumber, but this was confusing and didn't work
- don't show underconsumption anymore - always show the warning on the good being produced
- it's not a warning anymore if the net production is negative (to make all warnings and alerts actionable)
- add a new column showing workers that are not working
  - this includes persons and excludes expert soldiers, units that are fortified, improving or already have a destination
- add a column showing units that are working, but not working in their profession 

![image](https://user-images.githubusercontent.com/2832627/173177723-5b726606-056d-45f9-ae8b-248fcffd2b14.png)
