### PR TITLE
IR-246: Add the text "gold" after gold amounts

### DIFF
--- a/data/strings/FreeColMessages.properties
+++ b/data/strings/FreeColMessages.properties
@@ -2463,13 +2463,13 @@ model.monarch.action.addToRef.no=Done
 model.monarch.action.declarePeace.text=We have graciously agreed to a peace treaty with {{tag:country|%nation%}}.
 model.monarch.action.declarePeace.no=Done
 model.monarch.action.declareWar.text=The insolence of {{tag:country|%nation%}} forces Us to declare war on them!
-model.monarch.action.declareWarSupported.text=The insolence of the {{tag:country|%nation%}} forces Us to declare war on them! To expedite this matter, our loyal troops (%force%) await your orders, and a further sum of %gold% has been added to your treasury.
+model.monarch.action.declareWarSupported.text=The insolence of the {{tag:country|%nation%}} forces Us to declare war on them! To expedite this matter, our loyal troops (%force%) await your orders, and a further sum of %gold% gold has been added to your treasury.
 model.monarch.action.declareWar.no=Done
 model.monarch.action.displeasure.text=You dare to accept Our generous terms and yet evade payment? Such duplicity will reap the bitter reward of Our displeasure.
 model.monarch.action.displeasure.no=Done
 model.monarch.action.forceTax.text=We disdain your attempt to evade Our just taxation. The tax rate is now %amount%%.
 model.monarch.action.forceTax.no=Done
-model.monarch.action.hessianMercenaries.text=I, %leader%, have noted your military situation and graciously offer you the services of our loyal troops (%mercenaries%) for the sum of %gold%.
+model.monarch.action.hessianMercenaries.text=I, %leader%, have noted your military situation and graciously offer you the services of our loyal troops (%mercenaries%) for the sum of %gold% gold.
 model.monarch.action.hessianMercenaries.no=Alas, we cannot afford them.
 model.monarch.action.hessianMercenaries.yes=We accept
 model.monarch.action.hessianMercenaries.header=Foreign Correspondence
@@ -2479,7 +2479,7 @@ model.monarch.action.lowerTaxOther.text=In order to celebrate {{tag:%number%|0=O
 model.monarch.action.lowerTaxOther.no=Hurrah!
 model.monarch.action.lowerTaxWar.text=In order to celebrate Our recent victory against the treacherous {{tag:people|%nation%}}, We have graciously decided to lower your tax rate by %difference%%. The tax rate is now %newTax%%.
 model.monarch.action.lowerTaxWar.no=Hurrah!
-model.monarch.action.monarchMercenaries.text=In order to support you in our colonial wars, we have decided to provide you with some mercenaries (%mercenaries%) at a price of %gold%.
+model.monarch.action.monarchMercenaries.text=In order to support you in our colonial wars, we have decided to provide you with some mercenaries (%mercenaries%) at a price of %gold% gold.
 model.monarch.action.monarchMercenaries.no=Alas, we cannot afford them.
 model.monarch.action.monarchMercenaries.yes=We accept
 model.monarch.action.raiseTaxAct.text=The various acts of defiance perpetrated by the illoyal colonists of %newWorld% leave Us no choice but to impose a new {{tag:%number%|0=Navigation|1=Tea|2=Wool|3=Hat|4=Molasses|5=Stamp}} Act, raising your tax to %amount%%. If you do not accept We will be pleased to boycott your %goods%!
@@ -2649,7 +2649,7 @@ model.colony.cannotBuild=You are not building anything in %colony%.
 model.colony.colonistStarved=A colonist has starved to death in %colony%!
 model.colony.colonyStarved=The last colonist in %colony% has starved, leaving the colony abandoned.
 model.colony.customs.sale=The Customs House at %colony% sold: %data%.
-model.colony.customs.saleData=%amount% %goods% for %gold%
+model.colony.customs.saleData=%amount% %goods% for %gold% gold.
 model.colony.famineFeared=Famine feared in %colony%. Only %number% turns of food left.
 model.colony.starving=%colony% is starving.
 model.colony.newColonist=New colonist in %colony%.
@@ -2833,7 +2833,7 @@ boycottedGoods.dumpGoods=Dump Goods
 boycottedGoods.text=As %goods% have been boycotted by the Crown, you can not sell them in %europe%. Do you wish to pay your arrears (%amount% gold), or do you wish to dump the goods in the harbor, destroying them?
 buy.moreGold=Ask for lower price
 buy.takeOffer=Accept the offer
-buy.text=The %nation% would like to sell their %goods% for %gold%\n (European buy price: %euprice%)
+buy.text=The %nation% would like to sell their %goods% for %gold% gold.\n (European buy price: %euprice% gold)
 clearTradeRoute.text=Your %unit% is assigned to trade route %route%. Setting its destination will drop it from the trade route. Are you sure you want to do this?
 client.fullScreen=Full screen mode is not supported for this GraphicsDevice.\nFalling back to windowed mode.
 confirmHostile.alliance=You can not attack an allied nation! Do you really wish to break your alliance with {{tag:country|%nation%}} and declare war?
@@ -2886,7 +2886,7 @@ scoutSettlement.tribute=Demand tribute
 sell.gift=Offer the %goods% as a gift
 sell.moreGold=Ask for more gold
 sell.takeOffer=Accept the offer
-sell.text=The %nation% would like to buy your %goods% for %gold%\n (European sale price: %euprice%)
+sell.text=The %nation% would like to buy your %goods% for %gold% gold.\n (European sale price: %euprice% gold)
 stopCurrentGame.no=Cancel
 stopCurrentGame.text=A game is already running.
 stopCurrentGame.yes=Stop Game
@@ -3396,7 +3396,7 @@ buildQueuePanel.units=Units
 
 # CaptureGoodsDialog
 captureGoodsDialog.title=Loot Cargo
-captureGoodsDialog.europeanValue=European value: %gold%
+captureGoodsDialog.europeanValue=European value: %gold% gold.
 
 # CargoPanel
 cargoPanel.cargoAndSpace=Cargo on %name% (%space% {{plural:%space%|one=hold|other=holds|default=holds}} left)


### PR DESCRIPTION
Fixes/Addresses:
* [IR-246](https://sourceforge.net/p/freecol/improvement-requests/246/): #246 Add the word "gold" after gold amounts in texts