### PR TITLE
Ensure that Founding Father dialog is not too small

### DIFF
--- a/src/net/sf/freecol/client/gui/dialog/ChooseFoundingFatherDialog.java
+++ b/src/net/sf/freecol/client/gui/dialog/ChooseFoundingFatherDialog.java
@@ -22,7 +22,11 @@ package net.sf.freecol.client.gui.dialog;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.freecol.client.FreeColClient;

--- a/src/net/sf/freecol/client/gui/dialog/ChooseFoundingFatherDialog.java
+++ b/src/net/sf/freecol/client/gui/dialog/ChooseFoundingFatherDialog.java
@@ -22,10 +22,7 @@ package net.sf.freecol.client.gui.dialog;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
+import javax.swing.*;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.freecol.client.FreeColClient;
@@ -88,8 +85,13 @@ public final class ChooseFoundingFatherDialog
         tb.setSelectedIndex(0);
 
         JPanel panel = new MigPanel(new MigLayout("wrap 1", "align center"));
-        panel.add(Utility.localizedHeader("chooseFoundingFatherDialog.title",
-                                          Utility.FONTSPEC_TITLE));
+        JLabel title = Utility.localizedHeader("chooseFoundingFatherDialog.title",
+                Utility.FONTSPEC_TITLE);
+        if (title.getPreferredSize().getWidth() < 425) {
+            panel.add(title, "width 425");
+        } else {
+            panel.add(title);
+        }
         panel.add(helpButton, "tag help");
         panel.add(tb, "width 100%");
 


### PR DESCRIPTION
Ensure that Founding Father dialog is not too small, regardless of which language is used.
This is a fix for https://sourceforge.net/p/freecol/bugs/3291/

The cause of the problem is that with the current layout, the width of the dialog is controlled by the width of the title headline ("Nominate founding father"). If using another language where the title contains fewer letters, the panel containing the description of each founding father becomes more narrow, since the text panels will state that they prefer a very narrow layout. In my experiments, it was the tabs above the panels that determined the size of the panel.
And then the text instead is rendered with more rows, making the panel using much more vertical space than the dialog window allows for, making the "Ok" button end up outside of the visible window.

One could make the dialog allow for larger height of the dialog, or add vertical scroll bars if the panel is too high. But adding code that ensure that the dialog is never too narrow, makes the dialog look nicer, at least in the languages that I tried. 

Not so found of adding a constant width number, but perhaps it is a good enough solution?