### PR TITLE
Ability for Free Colonists to gain experience indoors

### DIFF
--- a/data/rules/freecol/specification.xml
+++ b/data/rules/freecol/specification.xml
@@ -57,6 +57,38 @@
     </building-type>
   </building-types>
 
+  <unit-change-types>
+    <unit-change-type id="model.unitChange.experience" preserve="true">
+      <unit-type-change id="model.unitChange.experience.masterCarpenter"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterCarpenter" probability="4"/>
+      <unit-type-change id="model.unitChange.experience.firebrandPreacher"
+                        from="model.unit.freeColonist"
+                        to="model.unit.firebrandPreacher" probability="2"/>
+      <unit-type-change id="model.unitChange.experience.elderStatesman"
+                        from="model.unit.freeColonist"
+                        to="model.unit.elderStatesman" probability="2"/>
+      <unit-type-change id="model.unitChange.experience.masterDistiller"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterDistiller" probability="3"/>
+      <unit-type-change id="model.unitChange.experience.masterWeaver"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterWeaver" probability="3"/>
+      <unit-type-change id="model.unitChange.experience.masterTobacconist"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterTobacconist" probability="3"/>
+      <unit-type-change id="model.unitChange.experience.masterFurTrader"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterFurTrader" probability="3"/>
+      <unit-type-change id="model.unitChange.experience.masterBlacksmith"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterBlacksmith" probability="3"/>
+      <unit-type-change id="model.unitChange.experience.masterGunsmith"
+                        from="model.unit.freeColonist"
+                        to="model.unit.masterGunsmith" probability="3"/>
+    </unit-change-type>
+  </unit-change-types>
+
   <founding-fathers>
     <founding-father id="model.foundingFather.franciscoDeCoronado"
                      type="exploration"


### PR DESCRIPTION
The current default behavior of FreeCol is that outdoor activities all carry up to a 4% chance that a Free Colonist could become an expert in the production area that they are working, regardless of skill level, all outdoor skills have up to a 4% chance, but there currently is no chance that a Free Colonist can gain experience when working indoors.

This Change:
* Adds the ability for Free Colonists to gain experience when producing goods indoors and become experts.
* Percentage (probability) is based on the skill level of the position.
  * The Carpenter is skill level 1, so has up to a 4% chance
  * Statesmen and Preachers are skill level 3, so have up to a 2% chance
  * All other occupations are skill level 2 and thus carry up to a 3% chance
