### PR TITLE
TrainPanel: allow 5 columns wrap to better support more units;

### DIFF
--- a/src/net/sf/freecol/client/gui/panel/TrainPanel.java
+++ b/src/net/sf/freecol/client/gui/panel/TrainPanel.java
@@ -36,7 +36,7 @@ public final class TrainPanel extends NewUnitPanel {
      * @param freeColClient The {@code FreeColClient} for the game.
      */
     public TrainPanel(FreeColClient freeColClient) {
-        super(freeColClient, new MigLayout("wrap 3", "[sg]", ""),
+        super(freeColClient, new MigLayout("wrap 5", "[sg]", ""),
             Messages.message("trainPanel.clickOn"),
             freeColClient.getGame().getSpecification()
                 .getUnitTypesTrainedInEurope(freeColClient.getMyPlayer()));


### PR DESCRIPTION
set 5 columns wrap to better support more units.
mods can overcrowd the default of 3 easily and the buttons disappear.