### PR TITLE
Skip video playback on Java 16+

### DIFF
--- a/src/net/sf/freecol/client/gui/Canvas.java
+++ b/src/net/sf/freecol/client/gui/Canvas.java
@@ -1601,7 +1601,17 @@ public final class Canvas extends JDesktopPane {
             runnable.run();
             return;
         }
-        
+
+        // Check if Applet class is available (removed in Java 11+)
+        try {
+            Class.forName("java.applet.Applet");
+        } catch (ClassNotFoundException e) {
+            // Applet class not available (Java 11+), skip video playback
+            logger.info("Skipping video playback: java.applet.Applet not available in this JVM");
+            runnable.run();
+            return;
+        }
+
         final String originalVendor = System.getProperty("java.vendor");
         if (originalVendor.indexOf(" ") == -1) {
             /* Cortado crashes unless there is a space in "java.vendor". */


### PR DESCRIPTION
After Java 11, Applet class becomes unavailable making the game break before getting to the main menu trying to play the intro. This can be circumvented passing --no-intro but the stacktrace message isn't too clear about what the problem is. The simplest solution for now seems to be to skip video playback and log the issue.