### PR TITLE
Fix arrow keys not moving units (secondary accelerators never bound)

### DIFF
--- a/src/net/sf/freecol/client/gui/action/MoveAction.java
+++ b/src/net/sf/freecol/client/gui/action/MoveAction.java
@@ -63,6 +63,11 @@ public class MoveAction extends MapboardAction {
         super(freeColClient, id + direction + ".secondary");
 
         this.direction = direction;
+
+        // Canvas only installs input-map bindings for actions with
+        // isCanvasKeyBinding(); without this the secondary accelerators
+        // (the arrow keys) are never bound and do nothing.
+        setCanvasKeyBinding(true);
     }
 
 


### PR DESCRIPTION
The secondary MoveAction constructor never calls setCanvasKeyBinding(true), so the arrow/Home/End/PgUp/PgDn accelerators from FreeColMessages.properties are never installed in the Canvas input map. Numpad works, arrows do nothing. Found on a laptop with no numpad, where there is currently no keyboard movement at all. One line.