### PR TITLE
Fix <delete> desync: mods can only delete one type per spec section

### DIFF
--- a/src/net/sf/freecol/common/model/Specification.java
+++ b/src/net/sf/freecol/common/model/Specification.java
@@ -219,6 +219,10 @@ public final class Specification implements OptionContainer {
                     } else {
                         logger.warning("Delete " + id + " failed");
                     }
+                    // Consume the </delete> end tag, otherwise the reader
+                    // desyncs and every element after the first <delete>
+                    // in the section is silently dropped.
+                    xr.closeTag(FreeColSpecObjectType.DELETE_TAG);
 
                 } else {
                     T object = getAlreadyInitializedType(id, type);


### PR DESCRIPTION
TypeReader's DELETE_TAG branch doesn't consume the end tag, so the reader desyncs after the first <delete> and everything after it in that section is dropped. You only find out via "No reader found for:" warnings in the log, if you look. Added the missing closeTag call.