### PR TITLE
Fix IndexOutOfBoundsException starting a game on a one-coast map

### DIFF
--- a/src/net/sf/freecol/server/generator/EuropeanStartingPositionsGenerator.java
+++ b/src/net/sf/freecol/server/generator/EuropeanStartingPositionsGenerator.java
@@ -310,10 +310,18 @@ class EuropeanStartingPositionsGenerator {
             switch (positionType) {
             case GameOptions.STARTING_POSITIONS_CLASSIC:
                 // Classic mode respects coast preference, the lists
-                // are pre-sampled and shuffled
-                start = ((startAtSea)
+                // are pre-sampled and shuffled.  On maps with sea on
+                // only one edge the preferred coast list can be empty;
+                // fall back to the other coast rather than crash.
+                List<Tile> preferred = (startAtSea)
                     ? ((startEast) ? eastSeaTiles : westSeaTiles)
-                    : ((startEast) ? eastLandTiles : westLandTiles)).remove(0);
+                    : ((startEast) ? eastLandTiles : westLandTiles);
+                if (preferred.isEmpty()) {
+                    preferred = (startAtSea)
+                        ? ((startEast) ? westSeaTiles : eastSeaTiles)
+                        : ((startEast) ? westLandTiles : eastLandTiles);
+                }
+                start = preferred.remove(0);
                 break;
             case GameOptions.STARTING_POSITIONS_RANDOM:
                 // Random mode is as classic but ignores coast


### PR DESCRIPTION
Made a Pacific-coast map (sea only on the west edge). Every nation except Russia has starts-on-east-coast=true, and EuropeanStartingPositionsGenerator does remove(0) on the east list, which is empty:

    java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.util.ArrayList.remove(ArrayList.java:551)
        at net.sf.freecol.server.generator.EuropeanStartingPositionsGenerator.determineStartingTilesWithoutUsingPredeterminedPositions(EuropeanStartingPositionsGenerator.java:316)

Patch falls back to the other coast when the preferred one has no tiles.