### PR TITLE
Notify former owner when a unit is captured in combat (fixes BR#3370)

### DIFF
--- a/src/net/sf/freecol/server/model/ServerPlayer.java
+++ b/src/net/sf/freecol/server/model/ServerPlayer.java
@@ -3031,6 +3031,16 @@ outer:  for (Effect effect : effects) {
             loser.setMovesLeft(0);
             loser.setState(Unit.UnitState.ACTIVE);
             cs.add(See.perhaps().always(loserPlayer), oldTile);
+            // csChangeOwner() only notifies the new owner (see
+            // exploreForUnit() call therein).  The former owner is never
+            // told the unit is gone, so its client retains a stale copy
+            // that keeps demanding orders each turn even though the
+            // server has already reassigned the unit - the "ghost unit"
+            // bug.  Explicitly tell the former owner to drop it, mirroring
+            // the See.only()/See.perhaps() split csSlaughterUnit() uses.
+            cs.addRemove((oldTile.getSettlement() != null)
+                ? See.only(loserPlayer) : See.perhaps().always(loserPlayer),
+                oldTile, loser);//-vis(loserPlayer)
             // Winner message post-capture when it owns the loser
             key = "combat.unitCaptured.enemy." + loser.getType().getSuffix();
             cs.addMessage(winnerPlayer,


### PR DESCRIPTION
## Summary

When a unit loses a combat and the result is that it gets **captured** (rather than killed, losing equipment, or demoted), the losing player's client was never told that the unit changed hands.

`ServerPlayer.csChangeOwner()` transfers ownership correctly on the server, but the only `ChangeSet` update it sends is to the *new* owner:

```java
cs.add(See.only(newOwner),
       ((ServerPlayer)newOwner).exploreForUnit(unit));
```

The former owner's client keeps its stale copy of the unit -- still theirs, still active, still with full moves -- so it keeps resurfacing as "needing orders" at every End Turn even though the server has already reassigned it. Trying to give it any order fails with "The server can not do that.", since the server no longer recognizes the client as the unit's owner.

## Fix

In `csCaptureUnit()`, after the ownership transfer succeeds, explicitly notify the former owner to drop the unit via `cs.addRemove(...)`, mirroring the `See.only()`/`See.perhaps()` visibility split `csSlaughterUnit()` already uses for the settlement/open-field cases.

Scoped to `csCaptureUnit()` rather than the shared `csChangeOwner()` utility, since `csChangeOwner()` has several other callers (colony capture, native conversion, REF defection) I have not individually verified are safe to change the same way -- they may share the same missing-notification pattern and could be worth a follow-up.

## Verification

- Diagnosed from a live game log: found the exact combat event (`Combat attacker=... Attack LOSE CAPTURE_UNIT`) and the subsequent client-side desync (client held the unit as `[unit:8805 english veteranSoldier]`, server responded to a move attempt with `Unit not owned by player:19: [unit:8805 russian freeColonist]`).
- Confirmed against a **fresh** in-game capture with the patch applied: the captured unit cleanly disappeared from the former owner's unit list, no stuck/ghost unit, no repeated "still waiting for orders" prompt.
- Compiles cleanly against current `sf-auto-merge` (`ant compile`, no errors).

Fixes https://sourceforge.net/p/freecol/bugs/3370/